### PR TITLE
Fix confusion between Iterable ABC and Iterable type

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -1,7 +1,9 @@
 import binascii
 import json
 from collections.abc import Iterable
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict
+from typing import Iterable as TIterable
+from typing import Optional, Union
 
 from jose import jwk
 from jose.backends.base import Key
@@ -51,7 +53,7 @@ def sign(payload: TPayload, key: Union[str, Dict[str, Any]], headers=None, algor
 def verify(
     token: Union[bytes, str],
     key: Union[str, Dict[str, Any]],
-    algorithms: Optional[Union[str, Iterable[str]]],
+    algorithms: Optional[Union[str, TIterable[str]]],
     verify: bool = True,
 ) -> bytes:
     """Verifies a JWS string's signature.


### PR DESCRIPTION
You appear to be trying to use `collections.abc.Iterable` in a type annotation:

```python
from collections.abc import Iterable
...
def verify(
    ...
    algorithms: Optional[Union[str, TIterable[str]]],
    verify: bool = True,
) -> bytes:
```

But I don't know if that's valid.

Whether it's valid or not, it's causing the CI failures [here](https://github.com/mpdavis/python-jose/pull/265/checks?check_run_id=2985384590) for [your PR](https://github.com/mpdavis/python-jose/pull/265):

```
  ==================================== ERRORS ====================================
  ___________________ ERROR collecting tests/test_firebase.py ____________________
  tests/test_firebase.py:5: in <module>
      from jose import jwt
  jose/jwt.py:7: in <module>
      from jose import jws
  jose/jws.py:55: in <module>
      verify: bool = True,
  E   TypeError: 'ABCMeta' object is not subscriptable
  ______________________ ERROR collecting tests/test_jws.py ______________________
  tests/test_jws.py:6: in <module>
      from jose import jwk, jws
  jose/jws.py:55: in <module>
      verify: bool = True,
  E   TypeError: 'ABCMeta' object is not subscriptable
  ______________________ ERROR collecting tests/test_jwt.py ______________________
  tests/test_jwt.py:7: in <module>
      from jose import jws, jwt
  jose/jws.py:55: in <module>
      verify: bool = True,
  E   TypeError: 'ABCMeta' object is not subscriptable
  __________________ ERROR collecting tests/rfc/test_rfc7520.py __________________
  tests/rfc/test_rfc7520.py:7: in <module>
      from jose.jws import verify
  jose/jws.py:55: in <module>
      verify: bool = True,
  E   TypeError: 'ABCMeta' object is not subscriptable
```

Note that the `verify: bool = True` has nothing to do with the issue or the fix. I don't know why Python has such bad error messages for this.

This PR implements the very simple fix - use `Iterable` from the `typing` module in the type annotations and alias it as `TIterable`.

I broke up the multiple imports from `typing` to keep `isort` happy.

[Branch CI results](https://github.com/blag/python-jose/runs/2987631181)